### PR TITLE
Calculate all round scoring locally before setting to context

### DIFF
--- a/src/components/Game/game.component.tsx
+++ b/src/components/Game/game.component.tsx
@@ -2,83 +2,57 @@ import { AppBar, Button, Toolbar, Typography } from '@mui/material';
 import ScoreBoard from 'components/ScoreBoard';
 import ScoreCard from 'components/ScoreCard';
 import GameOver from 'components/GameOver';
+import { calculateMakiWinners } from 'helpers/maki.helper';
 import { useRound, useScores } from 'hooks';
 import { IndividualRoundScore } from 'hooks/useScores';
 import React, { FC, useState } from 'react';
 import './game.styles.scss';
 
 const Game: FC = () => {
-    const { getPlayers, addMakiPoints, setIndividualScore, totalRoundScores } = useScores();
+    const { getPlayers, setPlayerRoundScore } = useScores();
     const { currentRound, advanceRound } = useRound();
     const players = getPlayers();
     const playerIds = Object.keys(players);
     const [showScores, setShowScores] = useState(false);
-    const [recordedScores, setRecordedScores] = useState<Array<IndividualRoundScore>>([]);
-
-    /**
-     * Helper function for generating Maki frequency map to player IDs
-     * @returns {Record<string, Array<string>>} Frequency map showing maki counts and corresponding player ids
-     */
-    const collectMakiCounts = (): Record<string, Array<string>> => {
-        const result: Record<string, Array<string>> = {};
-
-        for (const [playerId, scores] of Object.entries(players)) {
-            const currentRoundScores = scores.rounds[currentRound];
-            const roundMakiCount = currentRoundScores.makiQty;
-            if (roundMakiCount > 0) {
-                if (result[roundMakiCount]) {
-                    result[roundMakiCount].push(playerId);
-                } else {
-                    result[roundMakiCount] = [playerId];
-                }
-            }
-        }
-
-        return result;
-    };
-
-    /**
-     * Determine who has the most/second most maki count
-     * First place gets 6 points added to their score
-     * Second place gets 3 points added to their score
-     * In a tie, the points are split between those in the tie
-     * For odd numbered ties, the points are split rounding down
-     */
-    const calculateMakiWinners = () => {
-        const distribution = collectMakiCounts();
-        const orderedKeys = Object.keys(distribution).sort((a, b) => parseInt(b) - parseInt(a));
-
-        const firstPlace = orderedKeys[0];
-        const firstPlaceWinners = distribution[firstPlace] || [];
-        if (firstPlaceWinners.length) {
-            addMakiPoints(6, firstPlaceWinners);
-        }
-
-        if (orderedKeys.length > 1) {
-            const secondPlace = orderedKeys[1];
-            const secondPlaceWinners = distribution[secondPlace] || [];
-            addMakiPoints(3, secondPlaceWinners);
-        }
-    };
+    const [recordedScores, setRecordedScores] = useState<Record<string, IndividualRoundScore>>({});
 
     /**
      * Queue up individual round score to be submitted when round completes
-     * @param {IndividualRoundScore} score object for individual player per round
+     * @param {RoundScore} score object for individual player per round
      */
-    const recordIndividualScore = (score: IndividualRoundScore) => {
-        setRecordedScores(currentScores => [...currentScores, score]);
+    const recordIndividualScore = (playerId: string, score: IndividualRoundScore) => {
+        setRecordedScores(current => ({
+            ...current,
+            [playerId]: score,
+        }));
+    };
+
+    /**
+     * Iterate through recorded scores and dispatch an action for each player
+     * to set their finalized round score to context
+     * @param {Record<string,number>} makiWinners distribution of Maki winners to points to be awarded
+     */
+    const totalAndSetRoundScores = (makiWinners: Record<string, number>) => {
+        for (const [playerId, score] of Object.entries(recordedScores)) {
+            const { rawScore, makiQty, puddingQty } = score;
+            const makiScore = makiWinners[playerId] ?? score.makiScore;
+            const finalizedRoundScore: RoundScore = {
+                rawScore,
+                makiQty,
+                makiScore,
+                totalScore: rawScore + makiScore,
+            };
+
+            setPlayerRoundScore(playerId, finalizedRoundScore, puddingQty);
+        }
     };
 
     /**
      * Submits all recorded scores to state, perform final calculations, then shows scoreboard
      */
     const calculateRoundScores = () => {
-        for (const score of recordedScores) {
-            setIndividualScore(score);
-        }
-
-        calculateMakiWinners(); // TODO: Calculate this locally before setting to context
-        totalRoundScores();
+        const makiWinners = calculateMakiWinners(recordedScores);
+        totalAndSetRoundScores(makiWinners);
         setShowScores(true);
     };
 
@@ -102,7 +76,7 @@ const Game: FC = () => {
                         color="inherit"
                         variant="outlined"
                         onClick={calculateRoundScores}
-                        disabled={recordedScores.length < playerIds.length}
+                        disabled={Object.keys(recordedScores).length < playerIds.length}
                     >
                         Finish Round
                     </Button>
@@ -111,7 +85,7 @@ const Game: FC = () => {
             <ScoreBoard open={showScores} handleClose={closeScoreBoard} round={currentRound} players={players} />
             <div className="game--scorecard-container">
                 {playerIds.map((playerId: string) => (
-                    <div className="game--scorecard-item">
+                    <div key={playerId} className="game--scorecard-item">
                         <ScoreCard playerId={playerId} sendScores={recordIndividualScore} />
                     </div>
                 ))}

--- a/src/components/ScoreCard/scoreCard.component.tsx
+++ b/src/components/ScoreCard/scoreCard.component.tsx
@@ -8,7 +8,7 @@ import './scoreCard.styles.scss';
 
 interface ScoreCardProps {
     playerId: string;
-    sendScores: (scores: IndividualRoundScore) => void;
+    sendScores: (playerId: string, scores: IndividualRoundScore) => void;
 }
 
 const ScoreCard: FC<ScoreCardProps> = (props: ScoreCardProps) => {
@@ -22,8 +22,8 @@ const ScoreCard: FC<ScoreCardProps> = (props: ScoreCardProps) => {
     const [dumplingScore, setDumplingScore] = useState(0);
     const [tempuraScore, setTempuraScore] = useState(0);
     const [sashimiScore, setSashimiScore] = useState(0);
-    const [makiScore, setMakiScore] = useState(0);
-    const [puddingScore, setPuddingScore] = useState(0);
+    const [makiQty, setMakiQty] = useState(0);
+    const [puddingQty, setPuddingQty] = useState(0);
     const [submitted, setSubmitted] = useState(false);
 
     const total = useMemo(
@@ -42,19 +42,19 @@ const ScoreCard: FC<ScoreCardProps> = (props: ScoreCardProps) => {
         setDumplingScore(0);
         setTempuraScore(0);
         setSashimiScore(0);
-        setMakiScore(0);
-        setPuddingScore(0);
+        setMakiQty(0);
+        setPuddingQty(0);
         setSubmitted(false);
     };
 
     const handleSendScore = () => {
         const individualRoundScore: IndividualRoundScore = {
-            playerId,
             rawScore: total,
-            makiQty: makiScore,
-            puddingQty: puddingScore,
+            makiQty: makiQty,
+            makiScore: 0, // Temporarily set this to 0, may be recalculated later
+            puddingQty: puddingQty,
         };
-        sendScores(individualRoundScore);
+        sendScores(playerId, individualRoundScore);
         setSubmitted(true);
     };
 
@@ -68,8 +68,8 @@ const ScoreCard: FC<ScoreCardProps> = (props: ScoreCardProps) => {
                 <Item {...items.dumpling} score={dumplingScore} setScore={setDumplingScore} />
                 <Item {...items.tempura} score={tempuraScore} setScore={setTempuraScore} />
                 <Item {...items.sashimi} score={sashimiScore} setScore={setSashimiScore} />
-                <Item {...items.maki} score={makiScore} setScore={setMakiScore} />
-                <Item {...items.pudding} score={puddingScore} setScore={setPuddingScore} />
+                <Item {...items.maki} score={makiQty} setScore={setMakiQty} />
+                <Item {...items.pudding} score={puddingQty} setScore={setPuddingQty} />
             </div>
         </div>
     );

--- a/src/helpers/maki.helper.ts
+++ b/src/helpers/maki.helper.ts
@@ -1,0 +1,69 @@
+import { IndividualRoundScore } from 'hooks/useScores';
+
+/**
+ * Helper function for generating Maki frequency map to player IDs
+ * @param {Record<string, IndividualRoundScore>} recordedScores scores from the current round to parse for Maki counts
+ * @returns {Record<string, Array<string>>} Frequency map showing maki counts and corresponding player ids
+ */
+const collectMakiCounts = (recordedScores: Record<string, IndividualRoundScore>): Record<string, Array<string>> => {
+    const makiCounts: Record<string, Array<string>> = {};
+
+    for (const [playerId, scores] of Object.entries(recordedScores)) {
+        const playerMakiCount = scores.makiQty;
+        if (playerMakiCount > 0) {
+            if (makiCounts[playerMakiCount]) {
+                makiCounts[playerMakiCount].push(playerId);
+            } else {
+                makiCounts[playerMakiCount] = [playerId];
+            }
+        }
+    }
+
+    return makiCounts;
+};
+
+/**
+ * Helper function for distributing points from Maki winners
+ * Updates makiScore for Maki winners
+ * @param {number} totalPoints Total points to be distributed (6 for first, 3 for second)
+ * @param {Array<string>} winners List of player ids in each Maki group
+ * @param {Record<string,number>} makiWinners distribution of Maki winners to points to be awarded, populated by this function
+ */
+const updateMakiPoints = (totalPoints: number, winners: string[], makiWinners: Record<string, number>) => {
+    const points = Math.floor(totalPoints / winners.length);
+
+    for (const winnerId of winners) {
+        makiWinners[winnerId] = points;
+    }
+};
+
+/**
+ * Determine who has the most/second most maki count
+ * First place gets 6 points added to their score
+ * Second place gets 3 points added to their score
+ * In a tie, the points are split between those in the tie
+ * For odd numbered ties, the points are split rounding down
+ * @param {Record<string, IndividualRoundScore>} recordedScores scores from the current round to parse for Maki counts
+ * @returns {Record<string,number>} distribution of Maki winners to points to be awarded
+ */
+export const calculateMakiWinners = (recordedScores: Record<string, IndividualRoundScore>): Record<string, number> => {
+    const distribution = collectMakiCounts(recordedScores);
+    const orderedKeys = Object.keys(distribution).sort((a, b) => parseInt(b) - parseInt(a));
+
+    const firstPlace = orderedKeys[0];
+    const firstPlaceWinners = distribution[firstPlace] || [];
+
+    const makiWinners: Record<string, number> = {};
+
+    if (firstPlaceWinners.length) {
+        updateMakiPoints(6, firstPlaceWinners, makiWinners);
+    }
+
+    if (orderedKeys.length > 1) {
+        const secondPlace = orderedKeys[1];
+        const secondPlaceWinners = distribution[secondPlace] || [];
+        updateMakiPoints(3, secondPlaceWinners, makiWinners);
+    }
+
+    return makiWinners;
+};

--- a/src/hooks/useScores.ts
+++ b/src/hooks/useScores.ts
@@ -1,26 +1,19 @@
 import { useContext } from 'react';
 import { ScoresContext } from 'providers/Scores/scores.provider';
-import {
-    AddMakiScoreAction,
-    TotalRoundScoreAction,
-    SetScoreAction,
-    CreatePlayerAction,
-} from 'providers/Scores/scores.actions';
+import { CreatePlayerAction, SetPlayerRoundScoreAction } from 'providers/Scores/scores.actions';
 import useRound from './useRound';
 
 export interface IndividualRoundScore {
-    playerId: string;
     rawScore: number;
     makiQty: number;
+    makiScore: number;
     puddingQty: number;
 }
 interface useScoresType {
     scores: ScoresState;
     getPlayers: () => Record<string, Player>;
-    addMakiPoints: (totalPoints: number, winners: string[]) => void;
     createPlayer: (playerName: string) => void;
-    setIndividualScore: (score: IndividualRoundScore) => void;
-    totalRoundScores: () => void;
+    setPlayerRoundScore: (playerId: string, scores: RoundScore, puddingQty: number) => void;
 }
 
 const useScores = (): useScoresType => {
@@ -38,28 +31,6 @@ const useScores = (): useScoresType => {
     // Dispatch actions
 
     /**
-     * Helper function for distributing points from Maki winners
-     * @param {number} totalPoints Total points to be distributed (6 for first, 3 for second)
-     * @param {Array<string>} winners List of player ids in each Maki group
-     */
-    const addMakiPoints = (totalPoints: number, winners: string[]): void => {
-        const points = Math.floor(totalPoints / winners.length);
-
-        for (const winnerId of winners) {
-            const action: AddMakiScoreAction = {
-                type: 'ADD_MAKI_SCORE',
-                payload: {
-                    playerId: winnerId,
-                    round: currentRound,
-                    pointsToAdd: points,
-                },
-            };
-
-            dispatch(action);
-        }
-    };
-
-    /**
      * Dispatches an action to add a new player to ScoresContext
      * @param {string} playerName unique id used to identify player
      */
@@ -74,51 +45,27 @@ const useScores = (): useScoresType => {
     };
 
     /**
-     * Dispatches an action to submit an individual player's round scores
-     * @param {string} playerId Player to update
-     * @param {number} rawScore Total of static score values
-     * @param {number} makiQty Quantity of maki pieces collected during round
-     * @param {number} puddingQty Quantity of pudding pieces collected during round
+     * Dispatches an action to update a player's completed round score
+     * @param roundScore
      */
-    const setIndividualScore = (scores: IndividualRoundScore): void => {
-        const { playerId, rawScore, makiQty, puddingQty } = scores;
-        const action: SetScoreAction = {
-            type: 'SET_SCORE',
+    const setPlayerRoundScore = (playerId: string, scores: RoundScore, puddingQty: number) => {
+        const action: SetPlayerRoundScoreAction = {
+            type: 'SET_PLAYER_ROUND_SCORE',
             payload: {
-                playerId,
                 round: currentRound,
-                rawScore,
-                makiQty,
+                playerId,
+                scores,
                 puddingQty,
             },
         };
         dispatch(action);
     };
 
-    /**
-     * Dispatches an action to calculate finalized round scores for each player
-     */
-    const totalRoundScores = (): void => {
-        for (const playerId of Object.keys(scores.players)) {
-            const action: TotalRoundScoreAction = {
-                type: 'TOTAL_ROUND_SCORE',
-                payload: {
-                    playerId,
-                    round: currentRound,
-                },
-            };
-
-            dispatch(action);
-        }
-    };
-
     return {
         scores,
         getPlayers,
-        addMakiPoints,
         createPlayer,
-        setIndividualScore,
-        totalRoundScores,
+        setPlayerRoundScore,
     };
 };
 

--- a/src/providers/Scores/scores.actions.ts
+++ b/src/providers/Scores/scores.actions.ts
@@ -1,12 +1,3 @@
-export type AddMakiScoreAction = {
-    type: 'ADD_MAKI_SCORE';
-    payload: {
-        playerId: string;
-        round: number;
-        pointsToAdd: number;
-    };
-};
-
 export type CreatePlayerAction = {
     type: 'CREATE_PLAYER';
     payload: {
@@ -14,21 +5,12 @@ export type CreatePlayerAction = {
     };
 };
 
-export type SetScoreAction = {
-    type: 'SET_SCORE';
+export type SetPlayerRoundScoreAction = {
+    type: 'SET_PLAYER_ROUND_SCORE';
     payload: {
-        playerId: string;
         round: number;
-        rawScore: number;
-        makiQty: number;
+        playerId: string;
+        scores: RoundScore;
         puddingQty: number;
-    };
-};
-
-export type TotalRoundScoreAction = {
-    type: 'TOTAL_ROUND_SCORE';
-    payload: {
-        playerId: string;
-        round: number;
     };
 };

--- a/src/providers/Scores/scores.reducer.ts
+++ b/src/providers/Scores/scores.reducer.ts
@@ -1,35 +1,6 @@
-import { AddMakiScoreAction, CreatePlayerAction, SetScoreAction, TotalRoundScoreAction } from './scores.actions';
+import { CreatePlayerAction, SetPlayerRoundScoreAction } from './scores.actions';
 
-export type Actions = AddMakiScoreAction | CreatePlayerAction | SetScoreAction | TotalRoundScoreAction;
-
-/**
- * Adds the round-relative maki scoring to an individual player's makiScore
- * @param {ScoresState} state Current state
- * @param {AddMakiScoreAction} action Dispatch action with payload
- * @returns {ScoresState} Updated state
- */
-const addMakiScore = (state: ScoresState, action: AddMakiScoreAction): ScoresState => {
-    const { playerId, round, pointsToAdd } = action.payload;
-
-    const newRounds: RoundScore[] = state.players[playerId].rounds.map((entry, index) => {
-        if (index === round) {
-            entry.makiScore = pointsToAdd;
-        }
-
-        return entry;
-    });
-
-    return {
-        ...state,
-        players: {
-            ...state.players,
-            [playerId]: {
-                ...state.players[playerId],
-                rounds: newRounds,
-            },
-        },
-    };
-};
+export type Actions = CreatePlayerAction | SetPlayerRoundScoreAction;
 
 /**
  * Creates a new player in context
@@ -58,16 +29,18 @@ const createPlayer = (state: ScoresState, action: CreatePlayerAction): ScoresSta
 /**
  * Selects the desired player's rounds array, modifies the selected index
  * @param {ScoresState} state Current state
- * @param {SetScoresAction} action Dispatch action with payload
+ * @param {SetPlayerRoundScoreAction} action Dispatch action with payload
  * @returns {ScoresState} Updated state
  */
-const setPlayerScore = (state: ScoresState, action: SetScoreAction): ScoresState => {
-    const { playerId, round, rawScore, makiQty, puddingQty } = action.payload;
+const setPlayerRoundScore = (state: ScoresState, action: SetPlayerRoundScoreAction): ScoresState => {
+    const { round, playerId, scores, puddingQty } = action.payload;
+    const { rawScore, makiQty, makiScore, totalScore } = scores;
 
     const newRounds: RoundScore[] = state.players[playerId].rounds.map((entry, index) => {
         if (index === round) {
             entry.rawScore = rawScore;
             entry.makiQty = makiQty;
+            (entry.makiScore = makiScore), (entry.totalScore = totalScore);
         }
 
         return entry;
@@ -86,46 +59,13 @@ const setPlayerScore = (state: ScoresState, action: SetScoreAction): ScoresState
     };
 };
 
-/**
- * Calculates the total score for a given round and player
- * @param {ScoresState} state Current state
- * @param {TotalRoundScoresAction} action Dispatch action with payload
- * @returns {ScoresState} Updated state
- */
-const totalRoundScore = (state: ScoresState, action: TotalRoundScoreAction): ScoresState => {
-    const { playerId, round } = action.payload;
-
-    const newRounds: RoundScore[] = state.players[playerId].rounds.map((entry, index) => {
-        if (index === round) {
-            entry.totalScore = entry.rawScore + entry.makiScore;
-        }
-
-        return entry;
-    });
-
-    return {
-        ...state,
-        players: {
-            ...state.players,
-            [playerId]: {
-                ...state.players[playerId],
-                rounds: newRounds,
-            },
-        },
-    };
-};
-
 const reducer = (state: ScoresState, action: Actions): ScoresState => {
     console.log(action);
     switch (action.type) {
-        case 'ADD_MAKI_SCORE':
-            return addMakiScore(state, action);
         case 'CREATE_PLAYER':
             return createPlayer(state, action);
-        case 'SET_SCORE':
-            return setPlayerScore(state, action);
-        case 'TOTAL_ROUND_SCORE':
-            return totalRoundScore(state, action);
+        case 'SET_PLAYER_ROUND_SCORE':
+            return setPlayerRoundScore(state, action);
         default:
             return state;
     }


### PR DESCRIPTION
My first attempt at using Context wasn't very smart. Going to the well too many times.

I realized that I should be doing more work in the component state before dispatching finalized data to context. Given the current data structure of storing game data by player then round, this PR cuts down on the amount of calls to context by calculating the finalized round score for each player prior to dispatching a call to set each player score to context.

Future improvement: Flip the hierarchy in context and set only once per round.